### PR TITLE
Updated install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Installing Dependencies
 echo "Installing Dependencies..."
 sudo apt update
-sudo apt install git axel openjdk-21-jre openjdk-22-jre openjdk-23-jre -y
+sudo apt install git axel openjdk-21-jre openjdk-22-jre -y
 
 # Cloning
 git clone https://github.com/xiv3r/Burpsuite-Professional.git 


### PR DESCRIPTION
Oopenjdk-23-jre is removed from the official repo of kali so alot of people are getting error while installing it. Now it's fixed.