### PR TITLE
Fix: Update Burp Suite download URL for latest version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,6 @@
   burpSrc = fetchurl {
     name = "burpsuite.jar";
     urls = [
-      "https://portswigger-cdn.net/burp/releases/download?product=${productName}&version=${version}&type=Jar"
       "https://portswigger.net/burp/releases/download?product=${productName}&version=${version}&type=Jar"
       "https://web.archive.org/web/https://portswigger.net/burp/releases/download?product=${productName}&version=${version}&type=Jar"
     ];

--- a/install.ps1
+++ b/install.ps1
@@ -28,15 +28,13 @@ if (!($jre8)){
     $jre8
 }
 
-# Downloading Burp Suite Professional
-
-echo "`n`t`tDownloading Latest Burp Suite Professional..."
-$version = "latest"
-# Invoke-WebRequest -Uri "https://portswigger-cdn.net/burp/releases/download?product=pro&version=$version&type=Jar" `
-## Without Specific version it can auto downlaod latest version
-Invoke-WebRequest -Uri "https://portswigger-cdn.net/burp/releases/download?product=pro&type=Jar" `
--OutFile "burpsuite_pro_v$version.jar"
-echo "`nBurp Suite Professional is Downloaded.`n"
+# Download Burpsuite Professional
+Write-Host "Downloading Burp Suite Professional Latest..."
+$version = "2025"
+# Invoke-WebRequest -Uri "https://portswigger.net/burp/releases/download?product=pro&version=$version&type=Jar" `
+#   -OutFile "burpsuite_pro_v$version.jar"
+Invoke-WebRequest -Uri "https://portswigger.net/burp/releases/download?product=pro&type=Jar" `
+  -OutFile "burpsuite_pro_v$version.jar"
 
 # Creating Burp.bat file with command for execution
 if (Test-Path burp.bat) {rm burp.bat}

--- a/install.sh
+++ b/install.sh
@@ -10,9 +10,9 @@ git clone https://github.com/xiv3r/Burpsuite-Professional.git
 cd Burpsuite-Professional
 
 # Download Burpsuite Professional
-echo "Downloading Burpsuite Professional Latest..."
+echo "Downloading Burp Suite Professional Latest..."
 version=2025
-url="https://portswigger-cdn.net/burp/releases/download?product=pro&type=Jar"
+url="https://portswigger.net/burp/releases/download?product=pro&type=Jar"
 axel "$url" -o "burpsuite_pro_v$version.jar"
 
 # Execute Key Generator

--- a/install_macos.sh
+++ b/install_macos.sh
@@ -4,8 +4,8 @@ cd Burpsuite-Professional
 
 # Download Burpsuite Professional
 echo "Downloading Burp Suite Professional Latest..."
-version=2025.5.6
-url="https://portswigger-cdn.net/burp/releases/download?product=pro&type=Jar"
+version=2025
+url="https://portswigger.net/burp/releases/download?product=pro&type=Jar"
 curl -L "$url" -o "burpsuite_pro_v$version.jar"
 
 # Execute Key Generator and Burp Suite Simultaneously

--- a/update.sh
+++ b/update.sh
@@ -14,12 +14,12 @@ git clone https://github.com/xiv3r/Burpsuite-Professional.git
 cd Burpsuite-Professional
 
 # Download Burpsuite Professional
-echo "Downloading Burpsuite Professional Latest..."
-version=2025
-url="https://portswigger-cdn.net/burp/releases/download?product=pro&type=Jar"
+echo "Downloading Burp Suite Professional Latest..."
+version=2025.5.6
+url="https://portswigger.net/burp/releases/download?product=pro&type=Jar"
 axel "$url" -o "burpsuite_pro_v$version.jar"
 
-# Execute Key Generator
+# Execute Key Generator and Burp Suite Simultaneously
 echo "Starting Key loader.jar..."
 (java -jar loader.jar) &
 


### PR DESCRIPTION
previous url downloading old version v2025.5.6: 
Updated the download URL from portswigger-cdn.net to portswigger.net across all installation and update scripts. This resolves an issue where the scripts were failing to download Burp Suite Professional due to a change in the download domain.

Preserved the use of 'axel' in scripts where it was the original download tool, and 'curl' in others, maintaining the original structure of the scripts.